### PR TITLE
Fix sidebar generation for external users

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -23,7 +23,13 @@ const { parseMarkdownString } = require('@docusaurus/utils')
 // Ignore `.` files and directories, anything that isn't markdown and readme's
 const ignored = /(^\.)|(\.(?!md$))|(^readme\.md$)|^node_modules$/i
 
-const content_path = process.env.npm_package_config_docs_path;
+// Relative path from CWD to the site renderer
+const siteDir = process.env.npm_package_config_site_dir || "."
+
+// Relative path from siteDir to the docs content
+const docsPath = process.env.npm_package_config_docs_path
+
+const content_path = path.join(siteDir, docsPath)
 
 function parseFrontMatter(path) {
   const content = fs.readFileSync(path, 'utf8')

--- a/sidebars.js
+++ b/sidebars.js
@@ -21,7 +21,7 @@ const path = require('path')
 const { parseMarkdownString } = require('@docusaurus/utils')
 
 // Ignore `.` files and directories, anything that isn't markdown and readme's
-const ignored = /(^\.)|(\.(?!md$))|(^readme\.md$)/i
+const ignored = /(^\.)|(\.(?!md$))|(^readme\.md$)|^node_modules$/i
 
 const content_path = process.env.npm_package_config_docs_path;
 


### PR DESCRIPTION
Fixes an issue where the sidebar generation would fail when this repo was used as an dependency in an external content repo.

Adds an additional config item—`site_dir`— for specifying the base dir to use when forming relative links.

Fixes outstanding issue in #3.