### PR TITLE
Tab rendering

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,7 +51,7 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           include: ['{,!(node_modules)/**/}!(README).md'],
           showLastUpdateTime: true,
-          remarkPlugins: [
+          beforeDefaultRemarkPlugins: [
             require('./src/plugins/remark-tabs.js')
           ],
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,6 +51,9 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           include: ['{,!(node_modules)/**/}!(README).md'],
           showLastUpdateTime: true,
+          remarkPlugins: [
+            require('./src/plugins/remark-tabs.js')
+          ],
         },
         blog: false,
         pages: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7460,6 +7460,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdast-comment-marker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-comment-marker/-/mdast-comment-marker-1.1.2.tgz",
+      "integrity": "sha512-vTFXtmbbF3rgnTh3Zl3irso4LtvwUq/jaDvT2D1JqTGAwaipcS7RpTxzi6KjoRqI9n2yuAhzLDAC8xVTF3XYVQ=="
+    },
     "mdast-squeeze-paragraphs": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-4.0.0.tgz",
@@ -7474,6 +7479,14 @@
       "integrity": "sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==",
       "requires": {
         "unist-util-visit": "^2.0.0"
+      }
+    },
+    "mdast-util-heading-range": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-heading-range/-/mdast-util-heading-range-2.1.5.tgz",
+      "integrity": "sha512-jXbFD0C+MfRkwsaze+btzG9CmVrxnc5kpcJLtx3SvSlPWnNdGMlDRHKDB9/TIPEq9nRHnkixppT8yvaUJ5agJg==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.0"
       }
     },
     "mdast-util-to-hast": {
@@ -7495,6 +7508,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
+    },
+    "mdast-zone": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-zone/-/mdast-zone-4.0.1.tgz",
+      "integrity": "sha512-xWb6LpIWlDjaD5bT9/wDtCu/K7Ro/eu19jE2k8WzAzRaW6w9vwUyx+cXLBeTzPVoMyijJVVZxpLAl0bZOx9ikg==",
+      "requires": {
+        "mdast-comment-marker": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
     },
     "mdn-data": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@docusaurus/preset-classic": "2.0.0-alpha.70",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
+    "mdast-util-heading-range": "^2.1.5",
+    "mdast-zone": "^4.0.1",
     "placeos-docs": "github:placeos/docs",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/src/plugins/remark-tabs.js
+++ b/src/plugins/remark-tabs.js
@@ -1,52 +1,52 @@
 const visit = require('unist-util-visit')
-const parse5 = require('parse5')
+const u = require('unist-builder')
+const is = require('unist-util-is')
+const zone = require('mdast-zone')
+const heading = require('mdast-util-heading-range')
+const stringify = require('mdast-util-to-string')
 const Slugger = require('github-slugger')
 
 // Insert an import node to a mdast tree
 const injectImport = (tree, value) => {
   let seen = false
-  visit(tree, 'import', node => (node.value == value) ? seen = true : null)
-  if (!seen) { tree.children.push({type: 'import', value}) }
+  visit(tree, 'import', node => is(node, {value}) ? seen = true : null)
+  seen || tree.children.push(u('import', value))
 }
 
-// Rewrite jsx nodes containing a set of <details> elements as <Tab> components
+// Rewrite sections contained with `tabs` zone markers as <Tab> components
 module.exports = () => (tree, file) => {
-  visit(tree, 'jsx', node => {
-    let details = parse5.parseFragment(node.value).childNodes.filter(n => n.nodeName == 'details')
-
-    if (details.length < 2) { return }
+  zone(tree, 'tabs', (start, nodes, end) => {
+    let tabGroup = u('tabGroup', nodes)
 
     let slugger = new Slugger()
 
-    let tabs = details.map((elem) => {
-      let summary = elem.childNodes.findIndex(n => n.nodeName == 'summary')
+    // Group sections into `tab` nodes using headings as labels
+    while (tabGroup.children.find(node => is(node, 'heading'))) {
+      heading(tabGroup, () => true, (start, nodes, end) => {
+        let label = stringify(start)
+        let value = slugger.slug(label)
+        return [
+          u('tab', {label, value}, nodes),
+          end
+        ]
+      })
+    }
 
-      let label, value, body
-
-      [label, ] = elem.childNodes.splice(summary, 1)
-      label = parse5.serialize(label)
-
-      value = slugger.slug(label)
-
-      body = parse5.serialize(elem)
-
-      return {label, value, body}
-    })
+    let tabs = tabGroup.children.filter(node => is(node, 'tab'))
 
     injectImport(tree, "import Tabs from '@theme/Tabs';")
     injectImport(tree, "import TabItem from '@theme/TabItem';")
-    node.value = `
-      <Tabs
-        defaultValue="${tabs[0].value}"
-        values={[
-        ${tabs.map(({label, value}) =>
-          `{label: '${label}', value: '${value}'}`
-        ).join(',')}
-        ]}>
-        ${tabs.map(({value, body}) =>
-          `<TabItem value="${value}">${body}</TabItem>`
-        ).join('\n')}
-      </Tabs>
-    `
+
+    return [
+      u('jsx', `<Tabs defaultValue="${tabs[0].value}" values={[${tabs.map(({label, value}) => `{label: '${label}', value: '${value}'}`).join(',')}]}>`),
+      ...tabs.reduce((nodes, {value, children}) => (
+        nodes.concat([
+          u('jsx', `<TabItem value="${value}">`),
+          ...children,
+          u('jsx', `</TabItem>`)
+        ])
+      ), []),
+      u('jsx', `</Tabs>`)
+    ]
   })
 }

--- a/src/plugins/remark-tabs.js
+++ b/src/plugins/remark-tabs.js
@@ -37,6 +37,7 @@ module.exports = () => (tree, file) => {
     injectImport(tree, "import TabItem from '@theme/TabItem';")
     node.value = `
       <Tabs
+        defaultValue="${tabs[0].value}"
         values={[
         ${tabs.map(({label, value}) =>
           `{label: '${label}', value: '${value}'}`

--- a/src/plugins/remark-tabs.js
+++ b/src/plugins/remark-tabs.js
@@ -1,7 +1,37 @@
 const visit = require('unist-util-visit')
+const fromParse5 = require('hast-util-from-parse5')
+const parse5 = require('parse5')
+
+// Parse a mdast jsx node to a hast tree
+const toHast = (node) => fromParse5(parse5.parseFragment(node.value))
+
+const injectImports = (tree) => {
+  tree.children.push({type: 'import', value: "import Tabs from '@theme/Tabs';"})
+  tree.children.push({type: 'import', value: "import TabItem from '@theme/TabItem';"})
+}
 
 module.exports = () => (tree, file) => {
   visit(tree, 'jsx', node => {
-    console.log(node)
+    let hast = toHast(node)
+    console.log(hast)
+
+    visit(hast, {tagName: 'details'}, node => {
+       console.log(node.children)
+    })
+
+    node.value = `
+      <Tabs
+        defaultValue="apple"
+        values={[
+          {label: 'Apple', value: 'apple'},
+          {label: 'Orange', value: 'orange'},
+          {label: 'Banana', value: 'banana'},
+        ]}>
+        <TabItem value="apple">This is an apple 🍎</TabItem>
+        <TabItem value="orange">This is an orange 🍊</TabItem>
+        <TabItem value="banana">This is a banana 🍌</TabItem>
+      </Tabs>
+    `
+    injectImports(tree)
   })
 }

--- a/src/plugins/remark-tabs.js
+++ b/src/plugins/remark-tabs.js
@@ -9,9 +9,12 @@ const injectImport = (tree, value) => {
   if (!seen) { tree.children.push({type: 'import', value}) }
 }
 
+// Rewrite jsx nodes containing a set of <details> elements as <Tab> components
 module.exports = () => (tree, file) => {
   visit(tree, 'jsx', node => {
     let details = parse5.parseFragment(node.value).childNodes.filter(n => n.nodeName == 'details')
+
+    if (details.length < 2) { return }
 
     let slugger = new Slugger()
 
@@ -30,22 +33,19 @@ module.exports = () => (tree, file) => {
       return {label, value, body}
     })
 
-    if (tabs.length > 0) {
-      injectImport(tree, "import Tabs from '@theme/Tabs';")
-      injectImport(tree, "import TabItem from '@theme/TabItem';")
-      node.value = `
-        <Tabs
-          values={[
-          ${tabs.map(({label, value}) =>
-            `{label: '${label}', value: '${value}'}`
-          ).join(',')}
-          ]}>
-          ${tabs.map(({value, body}) =>
-            `<TabItem value="${value}">${body}</TabItem>`
-          ).join('\n')}
-        </Tabs>
-      `
-      console.log(node.value)
-    }
+    injectImport(tree, "import Tabs from '@theme/Tabs';")
+    injectImport(tree, "import TabItem from '@theme/TabItem';")
+    node.value = `
+      <Tabs
+        values={[
+        ${tabs.map(({label, value}) =>
+          `{label: '${label}', value: '${value}'}`
+        ).join(',')}
+        ]}>
+        ${tabs.map(({value, body}) =>
+          `<TabItem value="${value}">${body}</TabItem>`
+        ).join('\n')}
+      </Tabs>
+    `
   })
 }

--- a/src/plugins/remark-tabs.js
+++ b/src/plugins/remark-tabs.js
@@ -1,0 +1,7 @@
+const visit = require('unist-util-visit')
+
+module.exports = () => (tree, file) => {
+  visit(tree, 'jsx', node => {
+    console.log(node)
+  })
+}

--- a/src/plugins/remark-tabs.js
+++ b/src/plugins/remark-tabs.js
@@ -4,10 +4,9 @@ const Slugger = require('github-slugger')
 
 // Insert an import node to a mdast tree
 const injectImport = (tree, value) => {
-  let node = {type: 'import', value}
-  if (!tree.children.includes(node)) {
-    tree.children.push(node)
-  }
+  let seen = false
+  visit(tree, 'import', node => (node.value == value) ? seen = true : null)
+  if (!seen) { tree.children.push({type: 'import', value}) }
 }
 
 module.exports = () => (tree, file) => {


### PR DESCRIPTION
Adds support for rendering content sections as [Tab components](https://v2.docusaurus.io/docs/markdown-features/#tabs).

Resolves #13

---

To define a tab group, fence the content with a pair of `tabs start` and `tabs end` comments:

```markdown
<!--tabs start-->
# Foo
Why hello there.

# Bar
Oh hai!
<!--tabs end-->
```

Tabs will be created for each section, with headings forming the tab label.

![9ACBCDC1-FE42-413F-999B-134D8BA7474E](https://user-images.githubusercontent.com/843652/103902938-f54da880-5146-11eb-8e09-4adde09bf52b.jpeg)


Each tab can contain any supported nested elements of arbitrary complexity.

```markdown
<!--tabs start-->
# Baz

This includes text with _formatting_.

## Subheadings

    code blocks

| Even | Tables |
| ---- | ------ |
| like | this   |

<details>
  <summary>And HTML!</summary>
  With any content
</details>


# Qux
When a heading of the same level is encountered, this will segment into a new tab.

<!--tabs end-->
```

![658BD731-65DF-4704-A19E-E7C48BAEF006](https://user-images.githubusercontent.com/843652/103904289-d18b6200-5148-11eb-913a-cd4bdec88e5c.jpeg)
